### PR TITLE
Fixes branch checkout for pybullet-planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ pip install -e .
 ```
 mkdir externals && cd externals
 
-git clone https://github.com/branvu/pybullet-planning.git@coast_changes
+git clone --branch coast_changes https://github.com/branvu/pybullet-planning.git
 cd pybullet_planning
-git checkout coast_changes
 pip install -e .
 cd ..
 


### PR DESCRIPTION
Running
```
git clone https://github.com/branvu/pybullet-planning.git@coast_changes
```
produces
```
remote: Repository not found.
fatal: repository 'https://github.com/branvu/pybullet-planning.git@coast_changes/' not found
```

Proposed change to check out the branch `coast_changes` while cloning fixes this.